### PR TITLE
Testing more bar code devices

### DIFF
--- a/build/index.min.js
+++ b/build/index.min.js
@@ -40,7 +40,7 @@ var keyscanner = function () {
       enumerable: true,
       writable: true,
       value: function value(key, timeStamp) {
-        if (key !== 'Shift') {
+        if (!['Shift', 'Enter'].includes(key)) {
           _this.timeStampBuffer.push(timeStamp);
           _this.keyStrokeBuffer.push(key);
         }
@@ -95,7 +95,6 @@ var keyscanner = function () {
   }, {
     key: 'fetchBarcodeBuffer',
     value: function fetchBarcodeBuffer() {
-      this.keyStrokeBuffer.pop();
       return this.keyStrokeBuffer.join('');
     }
   }, {
@@ -104,22 +103,17 @@ var keyscanner = function () {
       var _this2 = this;
 
       var bufferLength = this.timeStampBuffer.length - 1;
-      var counter = 0,
-          lastHitKeyEnter = false;
+      var counter = 0;
       this.timeStampBuffer.forEach(function (timestamp, index) {
-        if (index < bufferLength) {
+        if (index <= bufferLength) {
           var diff = _this2.timeDifference(timestamp, _this2.timeStampBuffer[index + 1]);
           if (diff < _this2.BARCODE_THRESHOLD) {
             counter = counter + 1;
           }
-        } else {
-          if (_this2.keyStrokeBuffer[index] === 'Enter') {
-            lastHitKeyEnter = true;
-          }
         }
       });
       var achievedPercentage = counter * 100 / bufferLength;
-      return achievedPercentage > this.HUMAN_MACHINE_SPEED_THRESHOLD_PERCENTAGE && lastHitKeyEnter;
+      return achievedPercentage > this.HUMAN_MACHINE_SPEED_THRESHOLD_PERCENTAGE;
     }
   }]);
 

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ export default class keyscanner {
   };
 
   logInfo = (key, timeStamp) => {
-    if (key !== 'Shift') {
+    if (!['Shift','Enter'].includes(key)) {
       this.timeStampBuffer.push(timeStamp);
       this.keyStrokeBuffer.push(key);
     }
@@ -64,27 +64,21 @@ export default class keyscanner {
   }
 
   fetchBarcodeBuffer() {
-    this.keyStrokeBuffer.pop();
     return this.keyStrokeBuffer.join('');
   }
 
   isBarcodeMachine() {
     const bufferLength = this.timeStampBuffer.length - 1;
-    let counter = 0,
-      lastHitKeyEnter = false;
+    let counter = 0;
     this.timeStampBuffer.forEach((timestamp, index) => {
-      if (index < bufferLength) {
+      if (index <= bufferLength) {
         let diff = this.timeDifference(timestamp, this.timeStampBuffer[index + 1]);
         if (diff < this.BARCODE_THRESHOLD) {
           counter = counter + 1;
         }
-      } else {
-        if (this.keyStrokeBuffer[index] === 'Enter') {
-          lastHitKeyEnter = true;
-        }
       }
     });
     const achievedPercentage = (counter * 100) / bufferLength;
-    return achievedPercentage > this.HUMAN_MACHINE_SPEED_THRESHOLD_PERCENTAGE && lastHitKeyEnter;
+    return achievedPercentage > this.HUMAN_MACHINE_SPEED_THRESHOLD_PERCENTAGE;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "keyscanner",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "keyscanner",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keyscanner",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "./build/index.min.js",
   "description": "A library to detect automated keyboard events from external devices (such as a barcode scanner) and differentiates between human keystroke inputs with a high level of accuracy. This reader software, hence allows obtaining barcode information, without the user having to focus the cursor on a textfield.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keyscanner",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "./build/index.min.js",
   "description": "A library to detect automated keyboard events from external devices (such as a barcode scanner) and differentiates between human keystroke inputs with a high level of accuracy. This reader software, hence allows obtaining barcode information, without the user having to focus the cursor on a textfield.",
   "license": "MIT",


### PR DESCRIPTION
**The Problem:**
Different barcode devices can be configured in different manners, some to have an "Enter" pushed at the end of the scan, while some do it before the scan even begins.

Hence checking for an 'Enter' key hit within the code wasn't going to work.

**The Solution**

Stripping off all Enter and Shift Key inputs made by the Barcode Machine.
The internal KeyStrokeBuffer now does not store 'Enter' and 'Shift' keys. Those are just ignored.