### PR TITLE
Minimum barcode letters

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,14 @@ keyScanHandle.stop();
 ```js
     const config = {
         overall_percentage : 80,
-        key_stroke_speed_ms: 0.017 
+        key_stroke_speed_ms: 0.017,
+        minimum_no_chars: 5
     }
     const keyScanHandle = new keyscanner(myFuncOnScan, config);
 ```
 | Property | Description|
 |:---- |:---- |
-| overall_percentage      | The Overall percentage 1 - 100, at which scanner input passes the speed threshold mentioned in key_stroke_speed_ms|
-| key_stroke_speed_ms     | The speed in milli-seconds the scanner sends alphabets it scans. |
+| overall_percentage      | The Overall percentage 1 - 100, at which scanner input passes the speed threshold mentioned in key_stroke_speed_ms.
+(default 85, meaning 85% of the character input must be faster than the speed threshold mentioned in key_stroke_speed_ms)|
+| key_stroke_speed_ms     | The speed in milli-seconds the scanner sends alphabets it scans. (default: 0.017)|
+| minimum_no_chars | The minimum number of characters that a barcode should contain, inorder to get notified (default 4). Hence any inputs containing less than the value specified is ignored by keyscanner. |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ keyScanHandle.stop();
 ```
 | Property | Description|
 |:---- |:---- |
-| overall_percentage      | The Overall percentage 1 - 100, at which scanner input passes the speed threshold mentioned in key_stroke_speed_ms.
-(default 85, meaning 85% of the character input must be faster than the speed threshold mentioned in key_stroke_speed_ms)|
+| overall_percentage      | The Overall percentage 1 - 100, at which scanner input passes the speed threshold mentioned in key_stroke_speed_ms.(default 85, meaning 85% of the character input must be faster than the speed threshold mentioned in key_stroke_speed_ms)|
 | key_stroke_speed_ms     | The speed in milli-seconds the scanner sends alphabets it scans. (default: 0.017)|
 | minimum_no_chars | The minimum number of characters that a barcode should contain, inorder to get notified (default 4). Hence any inputs containing less than the value specified is ignored by keyscanner. |

--- a/build/index.min.js
+++ b/build/index.min.js
@@ -18,7 +18,8 @@ the user having to focus the cursor on a textfield.
 
 var DEFAULT_CONFIG = {
   overall_percentage: 85,
-  key_stroke_speed_ms: 0.017
+  key_stroke_speed_ms: 0.017,
+  minimum_no_chars: 4
 };
 
 var keyscanner = function () {
@@ -69,7 +70,8 @@ var keyscanner = function () {
     this.timerHandle = 1;
     this.initListenHandler();
     this.BARCODE_THRESHOLD = config.key_stroke_speed_ms || DEFAULT_CONFIG.key_stroke_speed_ms;
-    this.HUMAN_MACHINE_SPEED_THRESHOLD_PERCENTAGE = config.overall_percentage || DEFAULT_CONFIG.config.overall_percentage;
+    this.HUMAN_MACHINE_SPEED_THRESHOLD_PERCENTAGE = config.overall_percentage || DEFAULT_CONFIG.overall_percentage;
+    this.MINIMUM_NO_CHARS = config.minimum_no_chars || DEFAULT_CONFIG.minimum_no_chars;
     return {
       stop: this.stop
     };
@@ -113,7 +115,7 @@ var keyscanner = function () {
         }
       });
       var achievedPercentage = counter * 100 / bufferLength;
-      return achievedPercentage > this.HUMAN_MACHINE_SPEED_THRESHOLD_PERCENTAGE;
+      return achievedPercentage > this.HUMAN_MACHINE_SPEED_THRESHOLD_PERCENTAGE && counter + 1 >= this.MINIMUM_NO_CHARS;
     }
   }]);
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ the user having to focus the cursor on a textfield.
 
 const DEFAULT_CONFIG = {
   overall_percentage: 85,
-  key_stroke_speed_ms: 0.017
+  key_stroke_speed_ms: 0.017,
+  minimum_no_chars: 4
 };
 export default class keyscanner {
   constructor(callback, config = DEFAULT_CONFIG) {
@@ -17,7 +18,8 @@ export default class keyscanner {
     this.initListenHandler();
     this.BARCODE_THRESHOLD = config.key_stroke_speed_ms || DEFAULT_CONFIG.key_stroke_speed_ms;
     this.HUMAN_MACHINE_SPEED_THRESHOLD_PERCENTAGE =
-      config.overall_percentage || DEFAULT_CONFIG.config.overall_percentage;
+      config.overall_percentage || DEFAULT_CONFIG.overall_percentage;
+    this.MINIMUM_NO_CHARS = config.minimum_no_chars || DEFAULT_CONFIG.minimum_no_chars;
     return {
       stop: this.stop
     };
@@ -79,6 +81,7 @@ export default class keyscanner {
       }
     });
     const achievedPercentage = (counter * 100) / bufferLength;
-    return achievedPercentage > this.HUMAN_MACHINE_SPEED_THRESHOLD_PERCENTAGE;
+    return ((achievedPercentage > this.HUMAN_MACHINE_SPEED_THRESHOLD_PERCENTAGE) 
+    && (counter + 1 >= this.MINIMUM_NO_CHARS));
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "keyscanner",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "keyscanner",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "keyscanner",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keyscanner",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "./build/index.min.js",
   "description": "A library to detect automated keyboard events from external devices (such as a barcode scanner) and differentiates between human keystroke inputs with a high level of accuracy. This reader software, hence allows obtaining barcode information, without the user having to focus the cursor on a textfield.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keyscanner",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "./build/index.min.js",
   "description": "A library to detect automated keyboard events from external devices (such as a barcode scanner) and differentiates between human keystroke inputs with a high level of accuracy. This reader software, hence allows obtaining barcode information, without the user having to focus the cursor on a textfield.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keyscanner",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "./build/index.min.js",
   "description": "A library to detect automated keyboard events from external devices (such as a barcode scanner) and differentiates between human keystroke inputs with a high level of accuracy. This reader software, hence allows obtaining barcode information, without the user having to focus the cursor on a textfield.",
   "license": "MIT",


### PR DESCRIPTION
**The Problem:**

Sometimes, when the user tries to smash his keys really fast, it could trigger keyscanner because 2 or 3 characters passed the speed threshold limit. This was a false positive.

**The Solution**
Implemented a minimum number of characters that need to be available in order for the input scan to pass.

The patch also includes a minor bug fix related to the default config