### PR TITLE
Fix: for mobile barcode scanner (Honeywell handset)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 <img src="https://cdn.rawgit.com/namshi/keyscannerjs/master/scanner.svg" height="150" width="100%" align="middle"/>
 
 ## Overview
-KeyScanner is a library that allows reading input events from a barcode machine or other similar devices, and distinguish them from normal user keystrokes. 
-All barcode scanners can feed text into your application if your focused into a textfield however, KeyScanner does not require user focus in a textfield, and provides a simple API to obtain the scanned text.
-When you connect a barcode machine to your computer, and scan a code, KeyScanner intercepts those and makes it available to your application in an easy to use manner.
+KeyScanner is a library that allows reading input events from a barcode machine or other similar devices (like a mobile device with a barcode scanner), and distinguish them from normal user keystrokes. 
+All barcode scanners can feed text into your application if you're focused into a text field however, KeyScanner does not require user focus in a text field, and provides a simple API to obtain the scanned text.
+When you connect a barcode machine to your computer and scan a code, KeyScanner intercepts those and makes it available to your application in an easy to use manner.
 
 ## Quick Start Guide
 ```
@@ -42,6 +42,6 @@ keyScanHandle.stop();
 ```
 | Property | Description|
 |:---- |:---- |
-| overall_percentage      | The Overall percentage 1 - 100, at which scanner input passes the speed threshold mentioned in key_stroke_speed_ms.(default 85, meaning 85% of the character input must be faster than the speed threshold mentioned in key_stroke_speed_ms)|
+| overall_percentage      | The Overall percentage 1 - 100, at which scanner input passes the speed threshold mentioned in key_stroke_speed_ms.(default 95, meaning 95% of the character input must be faster than the speed threshold mentioned in key_stroke_speed_ms)|
 | key_stroke_speed_ms     | The speed in milli-seconds the scanner sends alphabets it scans. (default: 0.017)|
 | minimum_no_chars | The minimum number of characters that a barcode should contain, inorder to get notified (default 4). Hence any inputs containing less than the value specified is ignored by keyscanner. |

--- a/build/index.min.js
+++ b/build/index.min.js
@@ -17,7 +17,7 @@ the user having to focus the cursor on a textfield.
 */
 
 var DEFAULT_CONFIG = {
-  overall_percentage: 85,
+  overall_percentage: 95,
   key_stroke_speed_ms: 0.017,
   minimum_no_chars: 4
 };
@@ -41,7 +41,7 @@ var keyscanner = function () {
       enumerable: true,
       writable: true,
       value: function value(key, timeStamp) {
-        if (!['Shift', 'Enter'].includes(key)) {
+        if (!['Shift', 'Enter', 'Unidentified'].includes(key)) {
           _this.timeStampBuffer.push(timeStamp);
           _this.keyStrokeBuffer.push(key);
         }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ the user having to focus the cursor on a textfield.
 */
 
 const DEFAULT_CONFIG = {
-  overall_percentage: 85,
+  overall_percentage: 95,
   key_stroke_speed_ms: 0.017,
   minimum_no_chars: 4
 };
@@ -17,8 +17,7 @@ export default class keyscanner {
     this.timerHandle = 1;
     this.initListenHandler();
     this.BARCODE_THRESHOLD = config.key_stroke_speed_ms || DEFAULT_CONFIG.key_stroke_speed_ms;
-    this.HUMAN_MACHINE_SPEED_THRESHOLD_PERCENTAGE =
-      config.overall_percentage || DEFAULT_CONFIG.overall_percentage;
+    this.HUMAN_MACHINE_SPEED_THRESHOLD_PERCENTAGE = config.overall_percentage || DEFAULT_CONFIG.overall_percentage;
     this.MINIMUM_NO_CHARS = config.minimum_no_chars || DEFAULT_CONFIG.minimum_no_chars;
     return {
       stop: this.stop
@@ -35,7 +34,7 @@ export default class keyscanner {
   };
 
   logInfo = (key, timeStamp) => {
-    if (!['Shift','Enter'].includes(key)) {
+    if (!['Shift', 'Enter', 'Unidentified'].includes(key)) {
       this.timeStampBuffer.push(timeStamp);
       this.keyStrokeBuffer.push(key);
     }
@@ -80,8 +79,7 @@ export default class keyscanner {
         }
       }
     });
-    const achievedPercentage = (bufferLength >= this.MINIMUM_NO_CHARS)?(counter * 100) / bufferLength:0;
-    return ((achievedPercentage > this.HUMAN_MACHINE_SPEED_THRESHOLD_PERCENTAGE) 
-    && (bufferLength >= this.MINIMUM_NO_CHARS));
+    const achievedPercentage = bufferLength >= this.MINIMUM_NO_CHARS ? (counter * 100) / bufferLength : 0;
+    return achievedPercentage > this.HUMAN_MACHINE_SPEED_THRESHOLD_PERCENTAGE && bufferLength >= this.MINIMUM_NO_CHARS;
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "barcode",
     "scanner",
     "barcode scanner",
-    "key scanner"
+    "key scanner",
+    "mobile scanner",
+    "mobile barcode scanner"
   ],
   "files": [
     "README.md",


### PR DESCRIPTION
- Changed the default overall_percentage to 95, to reduce the chances of spurious input from the user.
- Added `unidentified` to the blacklist keys.